### PR TITLE
actually close the response Body per golang docs

### DIFF
--- a/lib/go/thrift/http_client.go
+++ b/lib/go/thrift/http_client.go
@@ -190,6 +190,12 @@ func (p *THttpClient) Flush() error {
 		// TODO(pomack) log bad response
 		return NewTTransportException(UNKNOWN_TRANSPORT_EXCEPTION, "HTTP Response code: "+strconv.Itoa(response.StatusCode))
 	}
+	// If we don't Close() any existing response Body, we may leak FDs.
+	if p.response != nil {
+		// We can't do anything useful with an error here, so we ignore the
+		// return value.
+		err = p.response.Body.Close()
+	}
 	p.response = response
 	return nil
 }


### PR DESCRIPTION
See the docs at http://golang.org/pkg/net/http/#Client.Do

In particular:

```
Callers should close resp.Body when done reading from it. If resp.Body is not
closed, the Client's underlying RoundTripper (typically Transport) may not be
able to re-use a persistent TCP connection to the server for a subsequent
"keep-alive" request.
```

I ran `crouton_example` and verified that the new `response.Body.Close()` gets called frequently (as one would expect). It remains to be seen if this actually fixes the fd leakage, but I have high hopes...
